### PR TITLE
feat: onActive and show schoolName in TermList

### DIFF
--- a/web/src/app/entity/response-body.ts
+++ b/web/src/app/entity/response-body.ts
@@ -1,0 +1,4 @@
+export interface ResponseBody {
+  success: boolean;
+  message: string;
+}

--- a/web/src/app/term/add/add.component.html
+++ b/web/src/app/term/add/add.component.html
@@ -34,25 +34,6 @@
     </div>
   </div>
   <div class="mb-3 row">
-    <label class="col-sm-2 col-form-label">状态</label>
-    <div class="col-sm-10">
-      <div class="form-check form-check-inline">
-        <input class="form-check-input" type="radio" id="normal"
-               name="status"
-               formControlName="status"
-               [value]="0">
-        <label class="form-check-label" for="normal">置入</label>
-      </div>
-      <div class="form-check form-check-inline">
-        <input class="form-check-input" type="radio" id="freeze"
-               name="status"
-               formControlName="status"
-               [value]="1">
-        <label class="form-check-label" for="freeze">冻结</label>
-      </div>
-    </div>
-  </div>
-  <div class="mb-3 row">
     <div class="col-sm-10 offset-2">
       <button class="btn btn-primary" [disabled]="formGroup.invalid">保存</button>
     </div>

--- a/web/src/app/term/add/add.component.ts
+++ b/web/src/app/term/add/add.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { TermService } from '../../../service/term.service';
-import Swal from 'sweetalert2';
 import { Term } from '../../entity/term';
 import { School } from '../../entity/school';
 import { HttpClient } from '@angular/common/http';
 import {ControlValueAccessor, FormControl, FormGroup, Validators} from '@angular/forms';
 import { Router } from '@angular/router';
+import {CommonService} from '../../../service/common.service';
 
 
 @Component({
@@ -15,10 +15,9 @@ import { Router } from '@angular/router';
 })
 export class AddComponent implements OnInit {
   formGroup = new FormGroup({
-    term: new FormControl('', [Validators.required, Validators.minLength(6)]),
+    term: new FormControl('', Validators.required),
     start_time: new FormControl(null, Validators.required),
     end_time: new FormControl(null, Validators.required),
-    status: new FormControl(null, Validators.required),
     school_id: new FormControl(null, Validators.required),
   });
   term = {} as Term;
@@ -26,7 +25,8 @@ export class AddComponent implements OnInit {
 
   constructor(private termService: TermService,
               private httpClient: HttpClient,
-              private router: Router) { }
+              private router: Router,
+              private commonService: CommonService) { }
 
   ngOnInit(): void {
     // 获取所有学校
@@ -49,41 +49,21 @@ export class AddComponent implements OnInit {
     term.end_time = term.end_time.getTime();
     term.start_time = term.start_time.getTime();
     this.termService.addTerm(term).subscribe(
-      response => {
-        console.log(response.success);
+      responseBody => {
+        console.log(responseBody.message);
         // 根据服务器返回的响应来显示成功或失败的弹窗
-        if (response.success) {
-          this.showSuccessAlert(response.message);
+        if (responseBody.success) {
+          this.commonService.showSuccessAlert(responseBody.message);
           // 新增成功，重定向到 term.component.html 对应的路由
           this.router.navigate(['/term']);
         } else {
-          this.showErrorAlert(response.message);
+          this.commonService.showErrorAlert(responseBody.message);
         }
       },
       error => {
         // 处理HTTP错误
-        this.showErrorAlert('请求失败，请稍后再试');
+        this.commonService.showErrorAlert('请求失败，请稍后再试');
       }
     );
-  }
-
-  // 显示成功弹窗
-  private showSuccessAlert(message: string): void {
-    Swal.fire({
-      icon: 'success',
-      title: '成功',
-      text: message,
-      showConfirmButton: false,
-      timer: 1500
-    });
-  }
-
-  // 显示失败弹窗
-  private showErrorAlert(message: string): void {
-    Swal.fire({
-      icon: 'error',
-      title: '错误',
-      text: message
-    });
   }
 }

--- a/web/src/app/term/edit/edit.component.html
+++ b/web/src/app/term/edit/edit.component.html
@@ -34,25 +34,6 @@
     </div>
   </div>
   <div class="mb-3 row">
-    <label class="col-sm-2 col-form-label">状态</label>
-    <div class="col-sm-10">
-      <div class="form-check form-check-inline">
-        <input class="form-check-input" type="radio" id="normal"
-               name="status"
-               formControlName="status"
-               [value]="0">
-        <label class="form-check-label" for="normal">置入</label>
-      </div>
-      <div class="form-check form-check-inline">
-        <input class="form-check-input" type="radio" id="freeze"
-               name="status"
-               formControlName="status"
-               [value]="1">
-        <label class="form-check-label" for="freeze">冻结</label>
-      </div>
-    </div>
-  </div>
-  <div class="mb-3 row">
     <div class="col-sm-10 offset-2">
       <button class="btn btn-primary" [disabled]="formGroup.invalid">保存</button>
     </div>

--- a/web/src/app/term/edit/edit.component.ts
+++ b/web/src/app/term/edit/edit.component.ts
@@ -5,8 +5,8 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
 import {Term} from '../../entity/term';
 import {HttpClient} from '@angular/common/http';
 import {School} from '../../entity/school';
-import Swal from 'sweetalert2';
-import { Router } from '@angular/router';
+import {Router} from '@angular/router';
+import {CommonService} from '../../../service/common.service';
 
 @Component({
   selector: 'app-edit',
@@ -20,14 +20,14 @@ export class EditComponent implements OnInit {
     term: new FormControl('', Validators.required),
     start_time: new FormControl(null, Validators.required),
     end_time: new FormControl(null, Validators.required),
-    status: new FormControl(null, Validators.required),
     school_id: new FormControl(null, Validators.required),
   });
 
   constructor(private activeRoute: ActivatedRoute,
               private termSeries: TermService,
               private httpClient: HttpClient,
-              private router: Router) {
+              private router: Router,
+              private commonService: CommonService){
   }
 
   ngOnInit(): void {
@@ -45,7 +45,6 @@ export class EditComponent implements OnInit {
       this.formGroup.patchValue({
         // 填充信息（编辑前的学期信息）
         term: term.term,
-        status: term.status,
         end_time: term.end_time,
         start_time: term.start_time,
         school_id: term.school_id
@@ -78,42 +77,22 @@ export class EditComponent implements OnInit {
     }
 
     this.termSeries.updateTerm(id, term).subscribe(
-      response => {
-        console.log(response.success);
+      responseBody => {
+        console.log(responseBody.success);
         // 根据服务器返回的响应来显示成功或失败的弹窗
-        if (response.success) {
-          this.showSuccessAlert(response.message);
+        if (responseBody.success) {
+          this.commonService.showSuccessAlert(responseBody.message);
           // 新增成功，重定向到 term.component.html 对应的路由
           this.router.navigate(['/term']);
         } else {
-          this.showErrorAlert(response.message);
+          this.commonService.showErrorAlert(responseBody.message);
         }
       },
       error => {
         // 处理HTTP错误
-        this.showErrorAlert('请求失败，请稍后再试');
+        this.commonService.showErrorAlert('请求失败，请稍后再试');
       }
     );
-  }
-
-  // 显示成功弹窗
-  private showSuccessAlert(message: string): void {
-    Swal.fire({
-      icon: 'success',
-      title: '成功',
-      text: message,
-      showConfirmButton: false,
-      timer: 1500
-    });
-  }
-
-  // 显示失败弹窗
-  private showErrorAlert(message: string): void {
-    Swal.fire({
-      icon: 'error',
-      title: '错误',
-      text: message
-    });
   }
 
   disableEndDate = (endDate: Date): boolean => {

--- a/web/src/app/term/term.component.html
+++ b/web/src/app/term/term.component.html
@@ -18,17 +18,19 @@
     <tbody>
     <tr *ngFor="let term of terms; index as i">
       <td>{{ i + 1 }}</td>
-      <td>天职师大</td>
+      <td>{{ getSchoolName(term.school_id) }}</td>
       <td>{{ term.term }}</td>
       <td>{{ term.start_time }}</td>
       <td>{{ term.end_time }}</td>
-      <td *ngIf="term.status; else termIsFreeze">冻结</td>
+      <td *ngIf="term.status; else termIsFreeze">
+        <span class="badge badge-pill badge-success">激活</span>
+      </td>
       <td>
         <a class="btn btn-outline-primary btn-sm" [routerLink]="'edit/' + term.id">
           <i class="fa fa-pen"></i>编辑
         </a>
-        <span *ngIf="term.status === 0" class="btn btn-sm btn-outline-danger">
-          <i class="fa fa-asterisk"></i>冻结
+        <span *ngIf="term.status === 0" class="btn btn-sm btn-outline-success" (click)="onActive(term.id)">
+          <i class="fa fa-refresh" aria-hidden="true"></i>激活
         </span>
       </td>
     </tr>
@@ -36,6 +38,8 @@
   </table>
 
   <ng-template #termIsFreeze>
-    <td>置入</td>
+    <td>
+      <span class="badge badge-pill badge-danger">冻结</span>
+    </td>
   </ng-template>
 </div>

--- a/web/src/app/term/term.component.ts
+++ b/web/src/app/term/term.component.ts
@@ -1,5 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { TermService } from '../../service/term.service';
+import { ActivatedRoute } from '@angular/router';
+import {CommonService} from '../../service/common.service';
+import {HttpClient} from '@angular/common/http';
+import {School} from '../entity/school';
 
 @Component({
   selector: 'app-term',
@@ -9,15 +13,49 @@ import { TermService } from '../../service/term.service';
 export class TermComponent implements OnInit {
   // 用于存储从后端获取的数据
   terms: any[] = [];
+  id: number;
+  schools = new Array<School>();
 
-  constructor(private termService: TermService) {
-    console.log('term组件成功注入termService', termService);
+  constructor(private termService: TermService,
+              private activeRoute: ActivatedRoute,
+              private commonService: CommonService,
+              private httpClient: HttpClient) {
   }
 
   ngOnInit(): void {
+    this.getAll();
+    // 获取学校
+    this.httpClient.get<School[]>('http://localhost:8088/api/school/index')
+      .subscribe(schoolJson => {
+        this.schools = schoolJson;
+        console.log(this.schools);
+      }, error => {
+        console.log(error);
+      });
+  }
+
+  getAll(): void {
     this.termService.getAllTerms().subscribe(terms => {
       this.terms = terms;
     });
   }
 
+  // 根据school_id找到对应学校名称
+  getSchoolName(schoolId: number): string {
+    const school = this.schools.find(s => s.id === schoolId);
+    return school ? school.school : '-';
+  }
+
+  onActive(id: number): void {
+    this.commonService.showConfirmAlert(() => {
+      this.termService.activeTerm(id).subscribe((responseBody) => {
+        if (responseBody.success) {
+          this.commonService.showSuccessAlert(responseBody.message);
+          this.getAll();
+        } else {
+          this.commonService.showErrorAlert(responseBody.message);
+        }
+      });
+    }, '是否激活, 此操作不可逆');
+  }
 }

--- a/web/src/service/common.service.spec.ts
+++ b/web/src/service/common.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CommonService } from './common.service';
+
+describe('CommonService', () => {
+  let service: CommonService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CommonService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/web/src/service/common.service.ts
+++ b/web/src/service/common.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import Swal, {SweetAlertResult} from 'sweetalert2';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CommonService {
+
+  constructor() { }
+
+  showSuccessAlert(message: string): void {
+    Swal.fire({
+      icon: 'success',
+      title: '成功',
+      text: message,
+      showConfirmButton: false,
+      timer: 1500
+    });
+  }
+
+  showErrorAlert(message: string): void {
+    Swal.fire({
+      icon: 'error',
+      title: '失败',
+      text: message
+    });
+  }
+
+  showConfirmAlert(callback?: () => void, description: string = '', title: string = '请确认'): void {
+    Swal.fire({
+      titleText: title,
+      text: description,
+      icon: 'question',
+      confirmButtonText: '是',
+      cancelButtonText: '否',
+      showCancelButton: true,
+      confirmButtonColor: '#007BFF',
+      showCloseButton: true
+    }).then((result: SweetAlertResult) => {
+      if (result.value) {
+        // 执行回调
+        if (callback) {
+          callback();
+        }
+      }
+    });
+  }
+}

--- a/web/src/service/term.service.ts
+++ b/web/src/service/term.service.ts
@@ -3,6 +3,7 @@ import {HttpClient} from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { Term} from '../app/entity/term';
+import {ResponseBody} from "../app/entity/response-body";
 
 @Injectable({
   providedIn: 'root'
@@ -18,12 +19,12 @@ export class TermService {
   }
 
   // 学期新增
-  addTerm(termData: { term: string; startTime: number; endTime: number; status: boolean; schoolId: number }): Observable<any> {
+  addTerm(termData: { term: string; startTime: number; endTime: number; status: boolean; schoolId: number }): Observable<ResponseBody> {
     // 构建完整的URL
     const addUrl = `${this.baseUrl}/add`;
 
     // 发送POST请求到后端
-    return this.http.post<Term>(addUrl, termData);
+    return this.http.post<ResponseBody>(addUrl, termData);
   }
 
   editTerm(id: number): Observable<any> {
@@ -34,5 +35,11 @@ export class TermService {
   updateTerm(id: number, termData: Term): Observable<any> {
     const updateUrl = `${this.baseUrl}/update/${id}`;
     return this.http.post(updateUrl, termData);
+  }
+
+  // 学期的激活
+  activeTerm(id: number): Observable<any> {
+    const activeUrl = `${this.baseUrl}/active/${id}`;
+    return this.http.get<any>(activeUrl);
   }
 }


### PR DESCRIPTION
1、完成了激活按钮，同时，设置了防止用户误触的设置，即在点击前会询问用户是否确定
2、保证了，同一个学校下，只有一个或零个学期是激活状态的
3、舍弃了在新增以及修改功能下，用户可以对学期状态进行修改的权限，学期状态只能通过激活按钮来修改
4、封装了commonService服务，专门用于弹窗提示
5、封装了response-body实体类，用于接收后台传到前台的response类型的json数据
![ADD27D73-0F5F-4810-9FAB-7A1D22ECAD7C](https://github.com/user-attachments/assets/15db0dc9-2939-4abc-9946-214d3f71eefd)
