### PR TITLE
feat:add teacher and user at the same time

### DIFF
--- a/htdocs/thinkphp5/application/common/model/User.php
+++ b/htdocs/thinkphp5/application/common/model/User.php
@@ -1,0 +1,7 @@
+<?php
+namespace app\common\model;
+use think\Model;
+
+class User extends Model {
+
+}

--- a/htdocs/thinkphp5/application/common/validate/TeacherValidate.php
+++ b/htdocs/thinkphp5/application/common/validate/TeacherValidate.php
@@ -1,0 +1,29 @@
+<?php
+namespace app\common\validate;
+use think\Validate;
+
+class TeacherValidate extends Validate {
+    protected $rule = [
+        'name' => 'require',
+        'teacher_no' => 'require',
+        'user_id' => 'require',
+        'password' => 'require',
+        'username' => 'require',
+        'role' => 'require',
+    ];
+
+    protected $message = [
+        'name.require' => '姓名不能为空',
+        'teacher_no' => '工号不能为空',
+        'user_id' => 'user_id设置错误',
+        'password' => '密码默认设置失败',
+        'username' => '用户名不能为空',
+        'role' => '角色默认设置失败',
+    ];
+
+    //  设置场景
+    protected $scene = [
+        'addUser' => ['username', 'password', 'role'],
+        'addTeacher' => ['name', 'teacher_no', 'user_id'],
+    ];
+}

--- a/htdocs/thinkphp5/application/index/controller/TeacherController.php
+++ b/htdocs/thinkphp5/application/index/controller/TeacherController.php
@@ -1,9 +1,71 @@
 <?php
 namespace app\index\controller;
 use app\common\model\Teacher;
+use app\common\model\User;
+use app\common\validate\TeacherValidate;
+use think\Db;
 use think\Request;
 
 class TeacherController extends IndexController {
+
+    public function add() {
+        // 接收前台的数据
+        $request = Request::instance()->getContent();
+        $data = json_decode($request, true);
+        // 查重
+        $teacherNo = $data['teacher_no'];
+        $teachers = Teacher::where('teacher_no', $teacherNo)->find();
+
+        if ($teachers) {
+            return json(['success' => false, 'message' => '该工号教师已存在，新增失败']);
+        }
+
+
+        // 开启事务
+        Db::startTrans();
+        try {
+            // 第一步，先新增 user 数据
+            $user = new User();
+            $user->username = $data['username'];
+            $user->password = $teacherNo;
+            $user->role = 2;
+
+            // 数据校验
+            $validate = new TeacherValidate;
+            if ($validate->scene('addUser')->check((array)$user)) {
+                // 验证失败，返回错误信息
+                return json(['success' => false, 'message' => $validate->getError()]);
+            }
+
+            if (!$user->save()) {
+                throw new \Exception('用户创建失败');
+            }
+
+            // 第二步，新增 teacher 数据，并将 user 的 id 作为 user_id 储存
+            $teacher = new Teacher();
+            $teacher->name = $data['name'];
+            $teacher->teacher_no = $teacherNo;
+            $teacher->user_id = $user->id;
+
+            // 数据验证
+            if ($validate->scene('addTeacher')->check((array)$teacher)) {
+                // 验证失败，返回错误信息
+                return json(['success' => false, 'message' => $validate->getError()]);
+            }
+
+            if (!$teacher->save()) {
+                throw new \Exception('教师创建失败');
+            }
+
+            // 提交事务
+            Db::commit();
+            return json(['success' => true, 'message' => '教师用户创建成功']);
+        } catch (\Exception $e) {
+            // 回滚事务
+            return json(['success' => false, 'message' => $e->getMessage()]);
+        }
+    }
+
     public function index() {
         $totalTeacher = Teacher::select();
         return json($totalTeacher);

--- a/web/src/app/entity/teacher.ts
+++ b/web/src/app/entity/teacher.ts
@@ -1,17 +1,17 @@
 export class Teacher {
   id: number;
   name: string;
+  username: string;
   // 学号
   // tslint:disable-next-line:variable-name
   teacher_no: string;
-  password: string;
   // tslint:disable-next-line:variable-name
   user_id: number;
   // tslint:disable-next-line:variable-name
-  constructor(id?: number, name?: string, password?: string, teacher_no?: string, user_id?: number) {
+  constructor(id?: number, name?: string, username?: string, teacher_no?: string, user_id?: number) {
     this.id = id as number;
     this.name = name as string;
-    this.password = password as string;
+    this.username = username as string;
     this.teacher_no = teacher_no as string;
     this.user_id = user_id as number;
   }

--- a/web/src/app/teacher/add/add.component.html
+++ b/web/src/app/teacher/add/add.component.html
@@ -1,0 +1,29 @@
+<form class="container-sm" [formGroup]="formGroup" (ngSubmit)="onSubmit()">
+  <div class="mb-3 row">
+    <label for="name" class="col-sm-2 col-form-label">姓名</label>
+    <div class="col-sm-10">
+      <input type="text" class="form-control" name="name" formControlName="name" id="name">
+      <div *ngIf="formGroup.get('name')?.invalid" class="text-danger mt-1">姓名不能为空</div>
+    </div>
+  </div>
+  <div class="mb-3 row">
+  <label for="username" class="col-sm-2 col-form-label">用户名</label>
+  <div class="col-sm-10">
+    <input type="text" class="form-control" name="username" formControlName="username" id="username">
+    <div *ngIf="formGroup.get('username')?.invalid" class="text-danger mt-1">用户名不能为空</div>
+  </div>
+  </div>
+  <div class="mb-3 row">
+    <label for="teacher_no" class="col-sm-2 col-form-label">工号</label>
+    <div class="col-sm-10">
+      <input type="text" class="form-control" name="teacher_no" formControlName="teacher_no" id="teacher_no">
+      <div *ngIf="formGroup.get('teacher_no')?.invalid" class="text-danger mt-1">工号不能为空</div>
+    </div>
+  </div>
+  <div class="mb-3 row">
+    <div class="col-sm-10 offset-2">
+      <button class="btn btn-primary" [disabled]="formGroup.invalid">保存</button>
+    </div>
+  </div>
+</form>
+

--- a/web/src/app/teacher/add/add.component.spec.ts
+++ b/web/src/app/teacher/add/add.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddComponent } from './add.component';
+
+describe('AddComponent', () => {
+  let component: AddComponent;
+  let fixture: ComponentFixture<AddComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AddComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/src/app/teacher/add/add.component.ts
+++ b/web/src/app/teacher/add/add.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import {FormControl, FormGroup, Validators} from '@angular/forms';
+import {CommonService} from '../../../service/common.service';
+import {TeacherService} from '../../../service/teacher.service';
+import {Router} from '@angular/router';
+
+
+@Component({
+  selector: 'app-add',
+  templateUrl: './add.component.html',
+  styleUrls: ['./add.component.css']
+})
+export class AddComponent implements OnInit {
+  formGroup = new FormGroup({
+    name: new FormControl('', Validators.required),
+    username: new FormControl('', Validators.required),
+    teacher_no: new FormControl(null, Validators.required),
+  });
+
+  constructor(private teacherService: TeacherService,
+              private commonService: CommonService,
+              private router: Router) { }
+
+  ngOnInit(): void {
+  }
+
+  onSubmit(): void {
+    console.log('点击了保存按钮');
+    const teacher = this.formGroup.value;
+    this.teacherService.add(teacher).subscribe(
+      responseBody => {
+        if (responseBody.success) {
+          this.commonService.showSuccessAlert(responseBody.message);
+          this.router.navigate(['/teacher']);
+        } else {
+          this.commonService.showErrorAlert(responseBody.message);
+        }
+      }, error => {
+        this.commonService.showErrorAlert('请求失败。请稍后');
+      }
+    );
+  }
+
+}

--- a/web/src/app/teacher/teacher.module.ts
+++ b/web/src/app/teacher/teacher.module.ts
@@ -3,24 +3,30 @@ import {CommonModule} from '@angular/common';
 import {RouterModule, Routes} from '@angular/router';
 import {ReactiveFormsModule} from '@angular/forms';
 import {TeacherComponent} from './teacher.component';
+import { AddComponent } from './add/add.component';
 
 
 const routes: Routes = [
   {
     path: '',
     component: TeacherComponent
+  },
+  {
+    path: 'add',
+    component: AddComponent
   }
 ];
 
 
 @NgModule({
   declarations: [
-    TeacherComponent
+    TeacherComponent,
+    AddComponent
   ],
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    RouterModule.forChild(routes),
+    RouterModule.forChild(routes)
   ]
 })
 export class TeacherModule { }

--- a/web/src/service/teacher.service.ts
+++ b/web/src/service/teacher.service.ts
@@ -13,6 +13,11 @@ export class TeacherService {
 
   constructor(private http: HttpClient) { }
 
+  // 新增
+  add(teacherData: Teacher): Observable<ResponseBody> {
+    const addUrl = `${this.baseUrl}/add`;
+    return this.http.post<ResponseBody>(addUrl, teacherData);
+  }
   // 获取所有教师
   getAll(): Observable<Teacher[]> {
     return this.http.get<Teacher[]>(this.baseUrl);


### PR DESCRIPTION
1、通过开启事务，实现教师的新增，同时user数据的新增，使得两条数据同时新增
2、修改了 teacher 表中的字段；现在 teacher 表中（id、name、teacher_no、user_id），user 表中的字段（id、username、password、role）
![add teacher](https://github.com/user-attachments/assets/ba662761-e707-48de-af81-e80b7585d348)
