### PR TITLE
bug:解决登录成功不跳转问题

### DIFF
--- a/web/src/app/layout/header/header.component.ts
+++ b/web/src/app/layout/header/header.component.ts
@@ -16,10 +16,10 @@ export class HeaderComponent implements OnInit {
               private router: Router) { }
 
   ngOnInit(): void {
-    this.loginService.getCurrentUser().subscribe();
-    this.loginService.currentLoginUser().subscribe(user => {
+    this.loginService.getCurrentUser().subscribe(user => {
       if (user) {
-        const jsonString = user.data;
+        const jsonString = user;
+        // @ts-ignore
         const userdata = JSON.parse(jsonString);
         this.username = userdata.username;
       }

--- a/web/src/app/personal-center/personal-center.component.ts
+++ b/web/src/app/personal-center/personal-center.component.ts
@@ -20,10 +20,10 @@ export class PersonalCenterComponent implements OnInit {
               private commonService: CommonService) { }
 
   ngOnInit(): void {
-    this.loginService.getCurrentUser().subscribe();
-    this.loginService.currentLoginUser().subscribe(user => {
+    this.loginService.getCurrentUser().subscribe(user => {
       if (user) {
-        const jsonString = user.data;
+        const jsonString = user;
+        // @ts-ignore
         const userdata = JSON.parse(jsonString);
         this.person.name = userdata.name;
         this.person.username = userdata.username;

--- a/web/src/interceptor/x-auth-token.interceptor.ts
+++ b/web/src/interceptor/x-auth-token.interceptor.ts
@@ -10,10 +10,6 @@ import {tap} from 'rxjs/operators';
 
 @Injectable()
 export class XAuthTokenInterceptor implements HttpInterceptor {
-  /**
-   * 从缓存中获取 x-auth-token，防止刷新后失效
-   */
-  private token = window.sessionStorage.getItem('x-auth-token');
 
   public static setToken(xAuthToken: string): void {
     if (xAuthToken) {
@@ -25,11 +21,14 @@ export class XAuthTokenInterceptor implements HttpInterceptor {
   }
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    // 每次从 sessionStorage 获取最新的 token
+    const token = sessionStorage.getItem('x-auth-token');
+    console.log(token);
     let authReq = request;
     // 如果 token 存在，克隆请求并将其添加到请求头中
-    if (this.token !== null) {
+    if (token !== null) {
       authReq = request.clone({
-        setHeaders: {'x-auth-token': this.token}
+        setHeaders: {'x-auth-token': token}
       });
     }
 

--- a/web/src/service/login.service.ts
+++ b/web/src/service/login.service.ts
@@ -51,6 +51,10 @@ export class LoginService {
       headers: new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded'),
       observe: 'response' // 设置 observe 为 response 以获取完整的响应对象
     }).pipe(tap( response => {
+      const token = response.headers.get('x-auth-token'); // 假设后端返回 `x-auth-token` 头
+      if (token) {
+        sessionStorage.setItem('x-auth-token', token); // 存储 token
+      }
       const user = JSON.parse(response.body.data) as User;
       this.setCurrentUser(user);
     }));


### PR DESCRIPTION
bug描述：登录成功后，页面不自动跳转；需要重新刷新页面，再次登录，才会进行跳转。
错因：在第一次登录时，拦截器中的 token 值为 null，这是因为在拦截器实例化时，token 的初始值还没有被存储到 sessionStorage 中，因此读取到的值是 null；
问题的关键：在于，拦截器读取 token 的时机，当用户第一次登录并获得 token 时，拦截器的 token 属性没有更新，因为它是在拦截器实例化时读取的